### PR TITLE
remove deprecated G8 methods while keeping G7 compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 rock_library(gazebo_underwater_msgs
     SOURCES  ${uw_msgs_SRCS}
-    HEADERS ${uw_msgs_HDR} DataTypes.hpp
+    HEADERS ${uw_msgs_HDR} DataTypes.hpp Gazebo7Shims.hpp
     DEPS_PKGCONFIG gazebo protobuf)
 
 rock_library(gazebo_underwater

--- a/src/DataTypes.hpp
+++ b/src/DataTypes.hpp
@@ -1,9 +1,8 @@
 #ifndef _DATATYPES_HPP_
 #define _DATATYPES_HPP_
 
+#include "Gazebo7Shims.hpp"
 #include <gazebo/common/common.hh>
-#include <gazebo/math/Vector3.hh>
-#include <gazebo/math/Matrix3.hh>
 #include <vector>
 #include "uw_msgs.pb.h"
 
@@ -12,19 +11,19 @@ namespace gazebo_underwater
 
 struct Matrix6
 {
-    gazebo::math::Matrix3 top_left;
-    gazebo::math::Matrix3 top_right;
-    gazebo::math::Matrix3 bottom_left;
-    gazebo::math::Matrix3 bottom_right;
+    ignition::math::Matrix3d top_left;
+    ignition::math::Matrix3d top_right;
+    ignition::math::Matrix3d bottom_left;
+    ignition::math::Matrix3d bottom_right;
 
     Matrix6():
-        top_left(gazebo::math::Matrix3::ZERO),
-        top_right(gazebo::math::Matrix3::ZERO),
-        bottom_left(gazebo::math::Matrix3::ZERO),
-        bottom_right(gazebo::math::Matrix3::ZERO)
+        top_left(ignition::math::Matrix3d::Zero),
+        top_right(ignition::math::Matrix3d::Zero),
+        bottom_left(ignition::math::Matrix3d::Zero),
+        bottom_right(ignition::math::Matrix3d::Zero)
     {}
-    Matrix6(const gazebo::math::Matrix3 &tl, const gazebo::math::Matrix3 &tr,
-                const gazebo::math::Matrix3 &bl, const gazebo::math::Matrix3 &br):
+    Matrix6(const ignition::math::Matrix3d &tl, const ignition::math::Matrix3d &tr,
+                const ignition::math::Matrix3d &bl, const ignition::math::Matrix3d &br):
         top_left(tl),
         top_right(tr),
         bottom_left(bl),
@@ -83,8 +82,8 @@ struct Matrix6
          *  C, D]      -D⁻¹C(A - BD⁻¹C)⁻¹, (D - CA⁻¹B)⁻¹]
          */
          Matrix6 inv;
-         gazebo::math::Matrix3 Sd = (this->top_left - this->top_right*this->bottom_right.Inverse()*this->bottom_left).Inverse();
-         gazebo::math::Matrix3 Sa = (this->bottom_right - this->bottom_left*this->top_left.Inverse()*this->top_right).Inverse();
+         ignition::math::Matrix3d Sd = (this->top_left - this->top_right*this->bottom_right.Inverse()*this->bottom_left).Inverse();
+         ignition::math::Matrix3d Sa = (this->bottom_right - this->bottom_left*this->top_left.Inverse()*this->top_right).Inverse();
          inv.top_left = Sd;
          inv.top_right = this->top_left.Inverse()*this->top_right*Sa*(-1);
          inv.bottom_left = this->bottom_right.Inverse()*this->bottom_left*Sd*(-1);
@@ -94,20 +93,20 @@ struct Matrix6
 
     static inline Matrix6 Identity()
     {
-       return  Matrix6(gazebo::math::Matrix3::IDENTITY, gazebo::math::Matrix3::ZERO,
-               gazebo::math::Matrix3::ZERO, gazebo::math::Matrix3::IDENTITY);
+       return  Matrix6(ignition::math::Matrix3d::Identity, ignition::math::Matrix3d::Zero,
+               ignition::math::Matrix3d::Zero, ignition::math::Matrix3d::Identity);
     }
 
-    inline gazebo_underwater::msgs::Matrix3 ConvertToMsg(const gazebo::math::Matrix3 &matrix) const
+    inline gazebo_underwater::msgs::Matrix3 ConvertToMsg(const ignition::math::Matrix3d &matrix) const
     {
-        gazebo::math::Vector3 vec;
+        ignition::math::Vector3d vec;
         gazebo_underwater::msgs::Matrix3 msg;
-        vec.Set(matrix[0][0], matrix[1][0], matrix[2][0]);
-        gazebo::msgs::Set(msg.mutable_x(), vec.Ign());
-        vec.Set(matrix[0][1], matrix[1][1], matrix[2][1]);
-        gazebo::msgs::Set(msg.mutable_y(), vec.Ign());
-        vec.Set(matrix[0][2], matrix[1][2], matrix[2][2]);
-        gazebo::msgs::Set(msg.mutable_z(), vec.Ign());
+        vec.Set(matrix(0,0), matrix(1,0), matrix(2,0));
+        gazebo::msgs::Set(msg.mutable_x(), vec);
+        vec.Set(matrix(0,1), matrix(1,1), matrix(2,1));
+        gazebo::msgs::Set(msg.mutable_y(), vec);
+        vec.Set(matrix(0,2), matrix(1,2), matrix(2,2));
+        gazebo::msgs::Set(msg.mutable_z(), vec);
         return msg;
     }
 
@@ -121,40 +120,40 @@ struct Matrix6
         return msg;
     }
 
-    inline gazebo::math::Matrix3 Matrix3(const gazebo_underwater::msgs::Matrix3 &msg) const
+    static inline ignition::math::Matrix3d ConvertFromMsg(const gazebo_underwater::msgs::Matrix3 &msg)
     {
-        gazebo::math::Matrix3 matrix;
-        matrix.SetFromAxes(gazebo::math::Vector3(gazebo::msgs::ConvertIgn(msg.x())),
-                gazebo::math::Vector3(gazebo::msgs::ConvertIgn(msg.y())),
-                gazebo::math::Vector3(gazebo::msgs::ConvertIgn(msg.z())));
+        ignition::math::Matrix3d matrix;
+        matrix.Axes(gazebo::msgs::ConvertIgn(msg.x()),
+                gazebo::msgs::ConvertIgn(msg.y()),
+                gazebo::msgs::ConvertIgn(msg.z()));
         return matrix;
     }
 
     Matrix6(const gazebo_underwater::msgs::Matrix6 &msg):
-        Matrix6(Matrix3(msg.tl()), Matrix3(msg.tr()),
-                Matrix3(msg.bl()), Matrix3(msg.br()))
+        Matrix6(ConvertFromMsg(msg.tl()), ConvertFromMsg(msg.tr()),
+                ConvertFromMsg(msg.bl()), ConvertFromMsg(msg.br()))
     {}
 };
 
 struct Vector6
 {
-    gazebo::math::Vector3 top;
-    gazebo::math::Vector3 bottom;
+    ignition::math::Vector3d top;
+    ignition::math::Vector3d bottom;
 
     Vector6()
+        : top(ignition::math::Vector3d::Zero)
+        , bottom(ignition::math::Vector3d::Zero)
     {
-        top = gazebo::math::Vector3::Zero;
-        bottom = gazebo::math::Vector3::Zero;
     }
-    Vector6(const gazebo::math::Vector3 &t, const gazebo::math::Vector3 &b)
+    Vector6(const ignition::math::Vector3d &t, const ignition::math::Vector3d &b)
+        : top(t)
+        , bottom(b)
     {
-        top = t;
-        bottom = b;
     }
     Vector6(const Vector6 &v)
+        : top(v.top)
+        , bottom(v.bottom)
     {
-        top = v.top;
-        bottom = v.bottom;
     }
     inline Vector6& operator*=(double value)
     {

--- a/src/Gazebo7Shims.hpp
+++ b/src/Gazebo7Shims.hpp
@@ -1,0 +1,60 @@
+#ifndef GAZEBO_7_SHIMS_HPP
+#define GAZEBO_7_SHIMS_HPP
+
+#include <ignition/math/Vector3.hh>
+#include <ignition/math/Matrix3.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+
+#include <gazebo/gazebo_config.h>
+#include <gazebo/math/Pose.hh>
+#include <gazebo/math/Matrix3.hh>
+
+#if GAZEBO_MAJOR_VERSION >= 8
+namespace gazebo_underwater
+{
+    ignition::math::Matrix3d const& IgnMatrix3(ignition::math::Matrix3d const& matrix)
+    {
+        return matrix;
+    }
+    ignition::math::Matrix3d const& GzMatrix3(ignition::math::Matrix3d const& matrix)
+    {
+        return matrix;
+    }
+
+}
+#define GzGet(object, getter, args) \
+	object.getter args
+#define GzGetIgn(object, getter, args) \
+	object.getter args
+#define ToIgn(value) \
+	value
+#else
+
+namespace gazebo_underwater
+{
+    ignition::math::Matrix3d IgnMatrix3(gazebo::math::Matrix3 const& matrix)
+    {
+	return ignition::math::Matrix3d(
+	   matrix[0][0], matrix[0][1], matrix[0][2],
+	   matrix[1][0], matrix[1][1], matrix[1][2],
+	   matrix[2][0], matrix[2][1], matrix[2][2]);
+    }
+    gazebo::math::Matrix3 GzMatrix3(ignition::math::Matrix3d const& matrix)
+    {
+	return gazebo::math::Matrix3(
+	   matrix(0, 0), matrix(0, 1), matrix(0, 2),
+	   matrix(1, 0), matrix(1, 1), matrix(1, 2),
+	   matrix(2, 0), matrix(2, 1), matrix(2, 2));
+    }
+
+}
+#define GzGet(object, getter, args) \
+	object.Get ## getter args
+#define GzGetIgn(object, getter, args) \
+	object.Get ## getter args.Ign()
+#define ToIgn(value) \
+	value.Ign()
+#endif
+
+#endif

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -7,6 +7,7 @@
 
 using namespace std;
 using namespace gazebo;
+using namespace ignition::math;
 
 namespace gazebo_underwater
 {
@@ -77,16 +78,15 @@ namespace gazebo_underwater
     physics::Inertial GazeboUnderwater::computeModelInertial(physics::ModelPtr model) const
     {
         Inertial inertial(0);
-        inertial.SetMOI(math::Matrix3::ZERO);
-        Inertial temp;
+        inertial.SetMOI(GzMatrix3(Matrix3d::Zero));
         physics::Link_V links = model->GetLinks();
         for (physics::Link_V::iterator it = links.begin(); it != links.end(); ++it)
             if(!(*it)->GetKinematic())
             {
                 // Set Inertial's CoG related with the parent link
-                temp = *(*it)->GetInertial();
-                math::Pose pose = (*it)->GetRelativePose();
-                pose.pos += pose.rot.RotateVector(temp.GetCoG());
+                Inertial temp = *(*it)->GetInertial();
+                Pose3d pose = GzGetIgn((**it), RelativePose, ());
+                pose.CoordPositionAdd(pose.Rot().RotateVector(GzGetIgn(temp, CoG, ())));
                 temp.SetCoG(pose);
                 inertial += temp;
             }
@@ -96,16 +96,16 @@ namespace gazebo_underwater
     void GazeboUnderwater::loadParameters(void)
     {
         waterLevel = getParameter<double>("water_level","meters", 0.0);
-        fluidVelocity = getParameter<math::Vector3>("fluid_velocity","m/s",math::Vector3(0,0,0));
+        fluidVelocity = getParameter<Vector3d>("fluid_velocity","m/s",Vector3d(0,0,0));
         modelInertial = computeModelInertial(model);
 
         // buoyancy must be the difference between the buoyancy when the model is completely submersed and the model weight
         buoyancy = getParameter<double>("buoyancy","N", 5);
-        buoyancy = abs(buoyancy) + modelInertial.GetMass() * model->GetWorld()->GetPhysicsEngine()->GetGravity().GetLength();
+        buoyancy = abs(buoyancy) + GzGet(modelInertial, Mass, ()) * world->Gravity().Length();
         // centerOfBuoyancy must be positioned related to the model's center of gravity.
-        centerOfBuoyancy = getParameter<math::Vector3>("center_of_buoyancy","meters",
-                math::Vector3(0, 0, 0.15));
-        centerOfBuoyancy += modelInertial.GetCoG();
+        centerOfBuoyancy = getParameter<Vector3d>("center_of_buoyancy","meters",
+                Vector3d(0, 0, 0.15));
+        centerOfBuoyancy += GzGetIgn(modelInertial, CoG, ());
         std::string damp_matrices;
         damp_matrices += "[50 0 0 0 0 0;";
         damp_matrices += "0 50 0 0 0 0;";
@@ -130,8 +130,8 @@ namespace gazebo_underwater
         extra_inertia += "0 0 0 0 0 0]";
         addedInertia = convertToMatrix(getParameter<string>("added_inertia","Kg, Kg.m2", extra_inertia));
 
-        gzInertia.top_left = modelInertial.GetMass() * math::Matrix3::IDENTITY;
-        gzInertia.bottom_right = modelInertial.GetMOI();
+        gzInertia.top_left = GzGet(modelInertial, Mass, ()) * Matrix3d::Identity;
+        gzInertia.bottom_right = IgnMatrix3(GzGet(modelInertial, MOI, ()));
         Matrix6 sum_inertia = gzInertia + addedInertia;
         gzmsg << "GazeboUnderwater: Inertia (Model_Inertia + Added_Inertia)" << endl;
         gzmsg << "Inertia top_left:     " << endl << sum_inertia.top_left;
@@ -147,8 +147,8 @@ namespace gazebo_underwater
             gzmsg <<"Damping["<<i<<"] bottom_right: " << endl << dampingCoefficients[i].bottom_right << endl;
         }
 
-        gzmsg << "GazeboUnderwater: Model's weight: "   << modelInertial.GetMass() * model->GetWorld()->GetPhysicsEngine()->GetGravity().GetLength() << " N" << endl;
-        gzmsg << "GazeboUnderwater: Model's CoG: ("     << modelInertial.GetCoG() << ") meters" << endl;
+        gzmsg << "GazeboUnderwater: Model's weight: "   << GzGet(modelInertial, Mass, ()) * model->GetWorld()->Gravity().Length() << " N" << endl;
+        gzmsg << "GazeboUnderwater: Model's CoG: ("     << GzGetIgn(modelInertial, CoG, ()) << ") meters" << endl;
         gzmsg << "GazeboUnderwater: Model's buoyancy: " << buoyancy << " N" << endl;
         gzmsg << "GazeboUnderwater: Model's CoB: ("     << centerOfBuoyancy << ") meters "<< endl;
 
@@ -161,7 +161,7 @@ namespace gazebo_underwater
 
     void GazeboUnderwater::updateBegin(common::UpdateInfo const& info)
     {
-        publishInertia(compInertia, modelInertial.GetCoG());
+        publishInertia(compInertia, GzGetIgn(modelInertial, CoG, ()));
         applyBuoyancy();
         applyDamp();
         applyCoriolisAddedInertia();
@@ -170,7 +170,7 @@ namespace gazebo_underwater
 
     void GazeboUnderwater::applyDamp()
     {
-        double distanceToSurface = waterLevel - link->GetWorldPose().pos.z;
+        double distanceToSurface = waterLevel - GzGetIgn((*link), WorldPose, ()).Pos().Z();
 
         if( distanceToSurface > 0 )
         {
@@ -179,13 +179,13 @@ namespace gazebo_underwater
             Vector6 damp;
             if(dampingCoefficients.size() == 2)
             {
-                Vector6 vel_square(vel.top*vel.top.GetAbs(), vel.bottom*vel.bottom.GetAbs());
+                Vector6 vel_square(vel.top*vel.top.Abs(), vel.bottom*vel.bottom.Abs());
                 damp = dampingCoefficients[0] * vel + dampingCoefficients[1] * vel_square;
             }
             else if(dampingCoefficients.size() == 6)
             {
                 Matrix6 dampMatrix;
-                Vector6 vel_abs(vel.top.GetAbs(), vel.bottom.GetAbs());
+                Vector6 vel_abs(vel.top.Abs(), vel.bottom.Abs());
                 for(size_t i=0; i < 3; i++)
                 {
                     dampMatrix += dampingCoefficients[i] * vel_abs.top[i];
@@ -201,44 +201,44 @@ namespace gazebo_underwater
 
             damp = compInertia * damp;
 
-            link->AddLinkForce(damp.top, modelInertial.GetCoG());
+            link->AddLinkForce(damp.top, GzGetIgn(modelInertial, CoG, ()));
             link->AddRelativeTorque(damp.bottom);
            }
        }
 
     void GazeboUnderwater::applyBuoyancy()
     {
-        double distanceToSurface = waterLevel - link->GetWorldPose().pos.z;
+        double distanceToSurface = waterLevel - GzGetIgn((*link), WorldPose, ()).Pos().Z();
         // The buoyancy is proportional to the submersed volume
         double submersedRatio = calculateSubmersedRatio(distanceToSurface);
 
-        math::Vector3 modelBuoyancy = math::Vector3(0,0,submersedRatio * buoyancy );
+        Vector3d modelBuoyancy = Vector3d(0,0,submersedRatio * buoyancy );
 
         Vector6 effort;
-        effort.top = link->GetWorldPose().rot.RotateVectorReverse(modelBuoyancy);
-        effort.bottom = (centerOfBuoyancy - modelInertial.GetCoG()).Cross(effort.top);
+        effort.top = GzGetIgn((*link), WorldPose, ()).Rot().RotateVectorReverse(modelBuoyancy);
+        effort.bottom = (centerOfBuoyancy - GzGetIgn(modelInertial, CoG, ())).Cross(effort.top);
 
         effort = compInertia * effort;
 
-        link->AddLinkForce(effort.top, modelInertial.GetCoG());
+        link->AddLinkForce(effort.top, GzGetIgn(modelInertial, CoG, ()));
         link->AddRelativeTorque(effort.bottom);
     }
 
     double GazeboUnderwater::calculateSubmersedRatio(double distanceToSurface) const
     {
-        math::Box linkBoudingBox = link->GetBoundingBox();
-        double linkVolume = linkBoudingBox.GetXLength() * linkBoudingBox.GetYLength() * linkBoudingBox.GetZLength();
+        Box linkBoudingBox = GzGetIgn((*link), BoundingBox, ());
+        double linkVolume = linkBoudingBox.XLength() * linkBoudingBox.YLength() * linkBoudingBox.ZLength();
         double submersedVolume = 0.0;
 
         if(distanceToSurface <= 0.0)
             submersedVolume = 0.0;
         else{
-            if(distanceToSurface <= (linkBoudingBox.GetZLength())/2.0 )
-                submersedVolume = linkBoudingBox.GetXLength() * linkBoudingBox.GetYLength() *
-                        ( linkBoudingBox.GetZLength()/2.0 + distanceToSurface );
+            if(distanceToSurface <= (linkBoudingBox.ZLength())/2.0 )
+                submersedVolume = linkBoudingBox.XLength() * linkBoudingBox.YLength() *
+                        ( linkBoudingBox.ZLength()/2.0 + distanceToSurface );
             else
-                submersedVolume = linkBoudingBox.GetXLength() * linkBoudingBox.GetYLength() *
-                        linkBoudingBox.GetZLength();
+                submersedVolume = linkBoudingBox.XLength() * linkBoudingBox.YLength() *
+                        linkBoudingBox.ZLength();
         }
         return submersedVolume/linkVolume;
     }
@@ -266,7 +266,7 @@ namespace gazebo_underwater
 
         coriolisEffect = compInertia * coriolisEffect;
 
-        link->AddLinkForce(coriolisEffect.top, modelInertial.GetCoG());
+        link->AddLinkForce(coriolisEffect.top, GzGetIgn(modelInertial, CoG, ()));
         link->AddRelativeTorque(coriolisEffect.bottom);
     }
 
@@ -297,12 +297,12 @@ namespace gazebo_underwater
                     momentum.top.Cross(velocities.top) + momentum.bottom.Cross(velocities.bottom));
 
         // Consider gravity
-        math::Vector3 weight( modelInertial.GetMass() * world->Gravity());
-        effort.top += link->GetWorldPose().rot.RotateVectorReverse( weight );
+        Vector3d weight( GzGet(modelInertial, Mass, ()) * world->Gravity() );
+        effort.top += GzGetIgn((*link), WorldPose, ()).Rot().RotateVectorReverse( weight );
 
         effort = compInertiaEye * effort;
 
-        link->AddLinkForce(effort.top, modelInertial.GetCoG());
+        link->AddLinkForce(effort.top, GzGetIgn(modelInertial, CoG, ()));
         link->AddRelativeTorque(effort.bottom);
     }
 
@@ -345,13 +345,13 @@ namespace gazebo_underwater
             for(size_t j=0; j<6; j++)
             {
                 if(i<3 && j<3)
-                    ret.top_left[i][j] = atof(line.at(j).c_str());
+                    ret.top_left(i,j) = atof(line.at(j).c_str());
                 else if(i<3 && j>=3)
-                    ret.top_right[i][j-3] = atof(line.at(j).c_str());
+                    ret.top_right(i,j-3) = atof(line.at(j).c_str());
                 else if(i>=3 && j<3)
-                    ret.bottom_left[i-3][j] = atof(line.at(j).c_str());
+                    ret.bottom_left(i-3,j) = atof(line.at(j).c_str());
                 else if(i>=3 && j>=3)
-                    ret.bottom_right[i-3][j-3] = atof(line.at(j).c_str());
+                    ret.bottom_right(i-3,j-3) = atof(line.at(j).c_str());
             }
         }
         return ret;
@@ -361,17 +361,18 @@ namespace gazebo_underwater
     {
         Vector6 velocities;
         // Calculates the difference between the model and fluid velocity relative to the world frame
-        math::Vector3 velocityDifference = link->GetWorldLinearVel(modelInertial.GetCoG()) - fluidVelocity;
-        velocities.top = link->GetWorldPose().rot.RotateVectorReverse( velocityDifference );
-        velocities.bottom = link->GetRelativeAngularVel();
+	Vector3d CoG = GzGetIgn(modelInertial, CoG, ());
+        Vector3d velocityDifference = GzGetIgn((*link), WorldLinearVel, (CoG)) - fluidVelocity;
+        velocities.top = GzGetIgn((*link), WorldPose, ()).Rot().RotateVectorReverse( velocityDifference );
+        velocities.bottom = GzGetIgn((*link), RelativeAngularVel, ());
         return velocities;
     }
 
-    void GazeboUnderwater::publishInertia(Matrix6 const& comp_inertia, gazebo::math::Vector3 const& cog)
+    void GazeboUnderwater::publishInertia(Matrix6 const& comp_inertia, Vector3d const& cog)
     {
         CompMassMSG compMassMSG;
         compMassMSG.mutable_matrix()->CopyFrom(comp_inertia.ConvertToMsg());
-        compMassMSG.mutable_cog()->CopyFrom(gazebo::msgs::Convert(cog.Ign()));
+        compMassMSG.mutable_cog()->CopyFrom(gazebo::msgs::Convert(cog));
         if(compensatedMassPublisher->HasConnections())
             compensatedMassPublisher->Publish(compMassMSG);
     }
@@ -383,7 +384,7 @@ namespace gazebo_underwater
         node->Init();
         string topicName = model->GetName() + "/compensated_mass";
         compensatedMassPublisher = node->Advertise<CompMassMSG>("~/" + topicName);
-        gzmsg <<"GazeboUnderwater: create gazebo topic /gazebo/"+ model->GetWorld()->GetName()
+        gzmsg <<"GazeboUnderwater: create gazebo topic /gazebo/"+ GzGet((*model->GetWorld()), Name, ())
             + "/" + topicName << endl;
     }
 }

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -86,7 +86,7 @@ namespace gazebo_underwater
                 // Set Inertial's CoG related with the parent link
                 Inertial temp = *(*it)->GetInertial();
                 Pose3d pose = GzGetIgn((**it), RelativePose, ());
-                pose.CoordPositionAdd(pose.Rot().RotateVector(GzGetIgn(temp, CoG, ())));
+                pose.Pos() += pose.Rot().RotateVector(GzGetIgn(temp, CoG, ()));
                 temp.SetCoG(pose);
                 inertial += temp;
             }

--- a/src/GazeboUnderwater.hpp
+++ b/src/GazeboUnderwater.hpp
@@ -1,9 +1,9 @@
 #ifndef _GAZEBOUNDERWATER_HPP_
 #define _GAZEBOUNDERWATER_HPP_
 
+#include "Gazebo7Shims.hpp"
 #include <gazebo/common/common.hh>
 #include <gazebo/physics/physics.hh>
-#include <gazebo/math/Vector3.hh>
 #include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/msgs.hh>
 #include "DataTypes.hpp"
@@ -32,7 +32,7 @@ namespace gazebo_underwater
             double calculateSubmersedRatio(double) const;
             Inertial computeModelInertial(ModelPtr model) const;
             Vector6 getModelFrameVelocities();
-            void publishInertia(Matrix6 const& comp_inertia, gazebo::math::Vector3 const& cog);
+            void publishInertia(Matrix6 const& comp_inertia, ignition::math::Vector3d const& cog);
             void initComNode(void);
 
             std::vector<Matrix6> convertToMatrices(const std::string &matrices);
@@ -64,8 +64,8 @@ namespace gazebo_underwater
             // linear velocities x,y,z followed by the angular velocities x,y,z
             std::vector<Matrix6> dampingCoefficients;
 
-            gazebo::math::Vector3 centerOfBuoyancy;
-            gazebo::math::Vector3 fluidVelocity;
+            ignition::math::Vector3d centerOfBuoyancy;
+            ignition::math::Vector3d fluidVelocity;
 
             double waterLevel;       // dimension in meter
             double buoyancy;


### PR DESCRIPTION
@joaobrittoneto I've done what I can to remove all the deprecation warnings from G8 while keeping G7 compatibility (both should compile fine). However, I don't have an environment to test it right now. Do you think you could test it ?