### PR TITLE
Fix buoyancy issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 *.sw?
+.vscode/

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -202,7 +202,6 @@ namespace gazebo_underwater
     {
         double submersedRatio = calculateSubmersedRatio();
         Vector3d modelBuoyancy = Vector3d(0, 0, submersedRatio * buoyancy);
-
         Vector6 effort;
         effort.top = GzGetIgn((*link), WorldPose, ()).Rot().RotateVectorReverse(modelBuoyancy);
         effort.bottom = (centerOfBuoyancy - GzGetIgn(modelInertial, CoG, ())).Cross(effort.top);
@@ -218,10 +217,9 @@ namespace gazebo_underwater
         Box linkBoundingBox = GzGetIgn((*link), BoundingBox, ());
         // Distance of the lower part of the bounding box to the surface
         // It is positive when submerged
-        double distanceToSurface = waterLevel - GzGetIgn((*link), WorldPose, ()).Pos().Z()
-            + linkBoundingBox.Min().Z();
-
+        double distanceToSurface = waterLevel - linkBoundingBox.Min().Z();
         double submersedRatio = distanceToSurface / linkBoundingBox.ZLength();
+        
         if (submersedRatio < 0)
             return 0;
         else if (submersedRatio > 1)

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -219,7 +219,7 @@ namespace gazebo_underwater
         // Distance of the lower part of the bounding box to the surface
         // It is positive when submerged
         double distanceToSurface = waterLevel - GzGetIgn((*link), WorldPose, ()).Pos().Z()
-            - linkBoundingBox.Min().Z();
+            + linkBoundingBox.Min().Z();
 
         double submersedRatio = distanceToSurface / linkBoundingBox.ZLength();
         if (submersedRatio < 0)


### PR DESCRIPTION
The `distanceToSurface` calculation seems to be incorrect since `linkBoundingBox.Min().Z()` is expressed in the world-frame and not in the body-frame as assumed by the previous calculation, explaining why the robot pose was also necessary in the calculation.

Thus, the distance to surface can be calculated by simply subtracting `linkBoundingBox.Min().Z()` from the water level. 

This fixes the behavior of the robot to achieve hydrostatic equilibrium in a inappropriate depth instead of doing so near the surface.

How to Test
----------------

* Run the simulation and make sure that no efforts besides buoyancy are applied to the body
* Check if hydrostatic equilibrium is achieved near surface, i.e. <a href="https://www.codecogs.com/eqnedit.php?latex=z&space;\approx&space;waterLevel" target="_blank"><img src="https://latex.codecogs.com/gif.latex?z&space;\approx&space;waterLevel" title="z \approx waterLevel" /></a>