### PR TITLE
use the boost-defined imported target instead of the deprecated variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,12 @@ find_package(Boost 1.40 COMPONENTS system REQUIRED)
 find_package(Protobuf REQUIRED)
 find_package(gazebo REQUIRED)
 
+if (TARGET Boost::system)
+    list(APPEND __boost_deps DEPS_TARGET Boost::system)
+else()
+    list(APPEND __boost_deps DEPS_PLAIN Boost)
+endif()
+
 foreach(ITR ${GAZEBO_INCLUDE_DIRS})
     if(ITR MATCHES ".*gazebo-[0-9]+$")
         set(PROTOBUF_IMPORT_DIRS "${ITR}/gazebo/msgs/proto")
@@ -23,9 +29,9 @@ rock_library(gazebo_underwater_msgs
 rock_library(gazebo_underwater
     SOURCES GazeboUnderwater.cpp
     HEADERS GazeboUnderwater.hpp
+    ${__boost_deps}
     DEPS_PKGCONFIG gazebo
-    DEPS gazebo_underwater_msgs
-    DEPS_CMAKE Boost)
+    DEPS gazebo_underwater_msgs)
 
 #install(FILES ${CMAKE_CURRENT_BINARY_DIR}/msgs.pb.h
 #    DESTINATION include/${PROJECT_NAME})


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/base-cmake/pull/59