### PR TITLE
feat: Allow choosing between recursive and non-recursive inertial calculation

### DIFF
--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -83,8 +83,8 @@ namespace gazebo_underwater
         inertial.SetMOI(GzMatrix3(Matrix3d::Zero));
         physics::Link_V links = model->GetLinks();
 
-        if(sdf->HasElement("disable_recursive_inertia_calculation") &&
-           sdf->Get<bool>("disable_recursive_inertia_calculation")) {
+        if(sdf->HasElement("inertial_calculation_using_main_link_only") &&
+           sdf->Get<bool>("inertial_calculation_using_main_link_only")) {
             return computeLinkInertial(link);
         }
 

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -83,17 +83,18 @@ namespace gazebo_underwater
         inertial.SetMOI(GzMatrix3(Matrix3d::Zero));
         physics::Link_V links = model->GetLinks();
 
-        if(sdf->HasElement("recursive_inertia_calculation")) {
-            for (physics::Link_V::iterator it = links.begin(); it != links.end(); ++it)
-                if(!(*it)->GetKinematic())
-                {
-                    // Set Inertial's CoG related with the parent link
-                    inertial += computeLinkInertial(*it);
-                }
-            return inertial;
+        if(sdf->HasElement("disable_recursive_inertia_calculation") &&
+           sdf->Get<bool>("disable_recursive_inertia_calculation")) {
+            return computeLinkInertial(link);
         }
 
-        return computeLinkInertial(link);
+        for (physics::Link_V::iterator it = links.begin(); it != links.end(); ++it)
+            if(!(*it)->GetKinematic())
+            {
+                // Set Inertial's CoG related with the parent link
+                inertial += computeLinkInertial(*it);
+            }
+        return inertial;
     }
 
     physics::Inertial GazeboUnderwater::computeLinkInertial(LinkPtr current_link) const {

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -98,7 +98,8 @@ namespace gazebo_underwater
 
     physics::Inertial GazeboUnderwater::computeLinkInertial(LinkPtr current_link) const {
         physics::Inertial link_inertial = *current_link->GetInertial();
-        Pose3d pose = GzGetIgn((*current_link), RelativePose, ());
+        Pose3d pose =
+            GzGetIgn((*current_link), RelativePose, ()) - GzGetIgn((*current_link), WorldPose, ());
         pose.Pos() += pose.Rot().RotateVector(GzGetIgn(link_inertial, CoG, ()));
         link_inertial.SetCoG(pose);
 

--- a/src/GazeboUnderwater.hpp
+++ b/src/GazeboUnderwater.hpp
@@ -30,7 +30,8 @@ namespace gazebo_underwater
             template <typename T>
             T getParameter(std::string parameter_name, std::string dimension, T default_value) const;
             double calculateSubmersedRatio() const;
-            Inertial computeModelInertial(ModelPtr model) const;
+            Inertial computeModelInertial(ModelPtr model, LinkPtr link, sdf::ElementPtr sdf) const;
+            Inertial computeLinkInertial(LinkPtr current_link) const;
             Vector6 getModelFrameVelocities();
             void publishInertia(Matrix6 const& comp_inertia, ignition::math::Vector3d const& cog);
             void initComNode(void);


### PR DESCRIPTION
Allow choosing between recursive and non-recursive inertial calculation,
This alongside being able to choose the `link_name` allows the user to concentrate
the whole mass of the model on the chosen link.

The option name is too big IMO, please give me suggestions. I also noticed it's `inertial` instead of `inertia` but since I intend to change it, I didn't bother changing it now.

EDIT1: Cannot change it to a draft