### PR TITLE
fix: resolution of link names in included models

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ rock_library(gazebo_underwater_msgs
     DEPS_PKGCONFIG gazebo protobuf)
 
 rock_library(gazebo_underwater
-    SOURCES GazeboUnderwater.cpp
+    SOURCES GazeboUnderwater.cpp RockGazeboHelpers.cpp
     HEADERS GazeboUnderwater.hpp
     ${__boost_deps}
     DEPS_PKGCONFIG gazebo

--- a/src/GazeboUnderwater.cpp
+++ b/src/GazeboUnderwater.cpp
@@ -6,6 +6,8 @@
 #include <stdlib.h>
 #include <regex>
 
+#include "RockGazeboHelpers.hpp"
+
 using namespace std;
 using namespace gazebo;
 using namespace ignition::math;
@@ -21,15 +23,15 @@ namespace gazebo_underwater
         node->Fini();
     }
 
-    void GazeboUnderwater::Load(physics::ModelPtr _model, sdf::ElementPtr _sdf)
+    void GazeboUnderwater::Load(physics::ModelPtr _model, sdf::ElementPtr _plugin_sdf)
     {
         gzmsg << "GazeboUnderwater: Loading underwater environment." << endl;
 
-        sdf = _sdf;
+        sdf = _plugin_sdf;
 
         model = _model;
         world = _model->GetWorld();
-        link  = getReferenceLink(model, _sdf);
+        link  = rock_gazebo_helpers::resolveLinkWithDefault(model, _plugin_sdf, "link_name");
         initComNode();
         loadParameters();
 
@@ -53,27 +55,6 @@ namespace gazebo_underwater
                     << default_value << ") " + dimension << endl;
         }
         return var;
-    }
-
-    physics::LinkPtr GazeboUnderwater::getReferenceLink(physics::ModelPtr model, sdf::ElementPtr sdf) const
-    {
-        if(sdf->HasElement("link_name"))
-        {
-            physics::LinkPtr link = model->GetLink( sdf->Get<string>("link_name") );
-            gzmsg << "GazeboUnderwater: reference link: " << link->GetName() << endl;
-            if (!link) {
-                string msg = "GazeboUnderwater: link " + sdf->Get<string>("link_name")
-                        + " not found in model " + model->GetName();
-                gzthrow(msg);
-            }
-            return link;
-        }else if (model->GetLinks().empty()) {
-            gzthrow("GazeboUnderwater: no link defined in model");
-        }else{
-            physics::LinkPtr link = model->GetLinks().front();
-            gzmsg << "GazeboUnderwater: reference link not defined, using instead: " << link->GetName() << endl;
-            return link;
-        }
     }
 
     physics::Inertial GazeboUnderwater::computeModelInertial(

--- a/src/GazeboUnderwater.hpp
+++ b/src/GazeboUnderwater.hpp
@@ -25,7 +25,6 @@ namespace gazebo_underwater
             void applyDamp();
             void applyCoriolisAddedInertia();
             void compensateGzEffort();
-            LinkPtr getReferenceLink(ModelPtr model, sdf::ElementPtr sdf) const;
             void loadParameters();
             template <typename T>
             T getParameter(std::string parameter_name, std::string dimension, T default_value) const;

--- a/src/RockGazeboHelpers.cpp
+++ b/src/RockGazeboHelpers.cpp
@@ -1,0 +1,191 @@
+#include "RockGazeboHelpers.hpp"
+#include <gazebo/common/Exception.hh>
+#include <regex>
+
+using namespace std;
+
+sdf::ElementPtr rock_gazebo_helpers::findPluginElement(sdf::ElementPtr enclosing,
+    string const& file_name)
+{
+    sdf::ElementPtr plugin_element = enclosing->GetElement("plugin");
+    while (plugin_element) {
+        if (plugin_element->Get<string>("filename") == file_name) {
+            gzmsg << "Found plugin: " << plugin_element->Get<string>("name") << " ("
+                  << file_name << ")" << endl;
+            return plugin_element;
+        }
+        plugin_element = plugin_element->GetNextElement("plugin");
+    }
+    return sdf::ElementPtr();
+}
+
+sdf::ElementPtr rock_gazebo_helpers::findPluginElementByName(sdf::ElementPtr enclosing,
+    string const& plugin_name)
+{
+    sdf::ElementPtr plugin_element = enclosing->GetElement("plugin");
+    while (plugin_element) {
+        if (plugin_element->Get<string>("name") == plugin_name) {
+            gzmsg << "Found plugin: " << plugin_element->Get<string>("name") << " ("
+                  << plugin_name << ")" << endl;
+            return plugin_element;
+        }
+        plugin_element = plugin_element->GetNextElement("plugin");
+    }
+    return sdf::ElementPtr();
+}
+
+sdf::ElementPtr rock_gazebo_helpers::getPluginElement(sdf::ElementPtr enclosing,
+    string const& file_name)
+{
+    auto element = findPluginElement(enclosing, file_name);
+
+    if (!element) {
+        // TODO: change this error message to be more generic
+        string msg = "GazeboThruster: sdf model loaded the thruster plugin, but it\n"
+                     "cannot be found in the SDF object. Expected the thruster plugin\n"
+                     "filename to be libgazebo_thruster.so\n";
+        gzthrow(msg);
+    }
+
+    return element;
+}
+
+sdf::ElementPtr rock_gazebo_helpers::getPluginElementByName(sdf::ElementPtr enclosing,
+    string const& plugin_name)
+{
+    auto element = findPluginElementByName(enclosing, plugin_name);
+
+    if (!element) {
+        string msg =
+            "Unable to find any plugin named " + plugin_name + " in the SDF object.\n";
+        gzthrow(msg);
+    }
+
+    return element;
+}
+
+string rock_gazebo_helpers::computeModelTopicScope(gazebo::physics::ModelPtr model)
+{
+    return "/gazebo/" + regex_replace(model->GetScopedName(true), regex("::"), "/");
+}
+
+string rock_gazebo_helpers::computePluginTopicScope(gazebo::physics::ModelPtr model,
+    sdf::ElementPtr plugin)
+{
+    string plugin_name = plugin->Get<string>("name");
+    if (plugin_name.find("__") != string::npos) {
+        return "/" + regex_replace(plugin_name, regex("__"), "/");
+    }
+    else {
+        string full_gazebo_name =
+            "gazebo::" + model->GetScopedName(true) + "::" + plugin_name;
+        return "/" + regex_replace(full_gazebo_name, regex("::"), "/");
+    }
+}
+
+static string resolveLinkScopeFromDoubleUndescoredPluginName(
+    gazebo::physics::ModelPtr model,
+    string const& plugin_name)
+{
+    // Do slightly better than the actual old implementation, and validate that
+    // the beginning of the full path is the fully scoped model name
+    auto expected_prefix_gazebo = "gazebo::" + model->GetScopedName(true);
+    auto expected_prefix = regex_replace(expected_prefix_gazebo, regex("::"), "__");
+    if (plugin_name.substr(0, expected_prefix.size()) != expected_prefix) {
+        gzthrow("expected " + plugin_name + " to start with " + expected_prefix);
+    }
+
+    auto rfind = plugin_name.rfind("__");
+    if (rfind == expected_prefix.size()) {
+        return "";
+    }
+
+    auto relative_scope = plugin_name.substr(expected_prefix.size() + 2,
+        rfind - expected_prefix.size() - 2);
+
+    cout << "name: " << plugin_name << "\n";
+    cout << "expected: " << expected_prefix << "\n";
+    cout << "rfind: " << rfind << "\n";
+    cout << "relative_scope: " << relative_scope << "\n";
+
+    return regex_replace(relative_scope, regex("__"), "::");
+}
+
+static string resolvePluginParentScope(gazebo::physics::ModelPtr model,
+    string const& plugin_name)
+{
+    if (plugin_name.find("__") != string::npos) {
+        return resolveLinkScopeFromDoubleUndescoredPluginName(model, plugin_name);
+    }
+    else {
+        return plugin_name.substr(0, plugin_name.rfind("::"));
+    }
+}
+
+static string applyScope(string const& scope, string const& name)
+{
+    if (scope.empty()) {
+        return name;
+    }
+    else {
+        return scope + "::" + name;
+    }
+}
+
+gazebo::physics::LinkPtr rock_gazebo_helpers::resolveLink(gazebo::physics::ModelPtr model,
+    sdf::ElementPtr plugin,
+    string const& link_name)
+{
+    string plugin_name = plugin->Get<string>("name");
+
+    auto scope = resolvePluginParentScope(model, plugin_name);
+    auto full_link_name = applyScope(scope, link_name);
+
+    auto link = model->GetLink(full_link_name);
+    if (!link) {
+        string msg = "could not find link " + link_name + " specified in plugin " +
+                     plugin_name + " (full link name resolved to " + full_link_name + ")";
+        gzthrow(msg);
+    }
+    return link;
+}
+
+gazebo::physics::LinkPtr rock_gazebo_helpers::resolveLinkWithDefault(
+    gazebo::physics::ModelPtr model,
+    sdf::ElementPtr plugin_sdf,
+    string const& element_name)
+{
+    if (plugin_sdf->HasElement(element_name)) {
+        auto link_name = plugin_sdf->Get<string>(element_name);
+        return resolveLink(model, plugin_sdf, link_name);
+    }
+    else if (model->GetLinks().empty()) {
+        gzthrow("No link defined in reference model, and no " + element_name +
+                " element found plugin");
+    }
+    else {
+        auto plugin_name = plugin_sdf->Get<string>("name");
+        auto scope = resolvePluginParentScope(model, plugin_name);
+        auto it = find_if(model->GetLinks().begin(),
+            model->GetLinks().end(),
+            [&](auto link_ptr) -> bool {
+                auto s = link_ptr->GetName();
+                return s.substr(0, scope.size()) == scope;
+            });
+
+        if (it == model->GetLinks().end()) {
+            gzthrow("Element " + element_name +
+                    " missing in plugin definition, attempted "
+                    "to find a link whose scoped name starts with " +
+                    scope +
+                    " but found "
+                    "none");
+        }
+
+        gzmsg << "Element " << element_name
+              << " missing in plugin definition, picking first "
+                 "link of the enclosing model, "
+              << (*it)->GetScopedName() << endl;
+        return *it;
+    }
+}

--- a/src/RockGazeboHelpers.cpp
+++ b/src/RockGazeboHelpers.cpp
@@ -103,11 +103,6 @@ static string resolveLinkScopeFromDoubleUndescoredPluginName(
     auto relative_scope = plugin_name.substr(expected_prefix.size() + 2,
         rfind - expected_prefix.size() - 2);
 
-    cout << "name: " << plugin_name << "\n";
-    cout << "expected: " << expected_prefix << "\n";
-    cout << "rfind: " << rfind << "\n";
-    cout << "relative_scope: " << relative_scope << "\n";
-
     return regex_replace(relative_scope, regex("__"), "::");
 }
 
@@ -117,9 +112,13 @@ static string resolvePluginParentScope(gazebo::physics::ModelPtr model,
     if (plugin_name.find("__") != string::npos) {
         return resolveLinkScopeFromDoubleUndescoredPluginName(model, plugin_name);
     }
-    else {
-        return plugin_name.substr(0, plugin_name.rfind("::"));
+
+    auto rfind = plugin_name.rfind("::");
+    if (rfind == string::npos) {
+        return "";
     }
+
+    return plugin_name.substr(0, rfind);
 }
 
 static string applyScope(string const& scope, string const& name)

--- a/src/RockGazeboHelpers.hpp
+++ b/src/RockGazeboHelpers.hpp
@@ -1,0 +1,128 @@
+#ifndef GAZEBO_THRUSTER_UTILITIES_HPP
+#define GAZEBO_THRUSTER_UTILITIES_HPP
+
+#include <gazebo/common/Console.hh>
+#include <gazebo/physics/physics.hh>
+#include <sdf/sdf.hh>
+
+/** Generic helpers helpful to develop plugins in relation (but with no dependencies on)
+ * rock-gazebo
+ *
+ * Using these heleprs do NOT create a dependency on rock-gazebo. They are generic
+ * helpers for the most part, and also implement the way rock-gazebo allows to
+ * handle hierarchical models meaningfully. This last part is a set of
+ * principles/best practices and not a direct dependency.
+ *
+ * We did not want to create a full package to distribute them ... they are meant
+ * to be copied to the package(s) where they are needed.
+ */
+namespace rock_gazebo_helpers {
+    /** Looks for a <plugin> element
+     *
+     * This methods searches for a plugin element, direct child of
+     * \c enclosing, whose filename is the given file name. It differs
+     * from \c getPluginElement by the way it handles the missing case.
+     *
+     * @return a null pointer if the plugin could not be found
+     * @see getPluginElement
+     */
+    sdf::ElementPtr findPluginElement(sdf::ElementPtr enclosing,
+        std::string const& fileName);
+
+    /** Looks for a <plugin> element
+     *
+     * This methods searches for a plugin element, direct child of
+     * \c enclosing, whose name is the given name. It differs
+     * from \c getPluginElement by the way it handles the missing case.
+     *
+     * @return a null pointer if the plugin could not be found
+     * @see getPluginElement
+     */
+    sdf::ElementPtr findPluginElementByName(sdf::ElementPtr enclosing,
+        std::string const& plugin_name);
+
+    /** Resolves for a <plugin> element
+     *
+     * This methods searches for a plugin element, direct child of
+     * \c enclosing, whose filename is the given file name. It differs
+     * from \c findPluginElement by the way it handles the missing case.
+     *
+     * @throw invalid_argument if the plugin could not be found
+     * @see findPluginElement
+     */
+    sdf::ElementPtr getPluginElement(sdf::ElementPtr enclosing,
+        std::string const& fileName);
+
+    /** Resolves for a <plugin> element
+     *
+     * This methods searches for a plugin element, direct child of
+     * \c enclosing, whose name is the given name. It differs
+     * from \c findPluginElementByName by the way it handles the missing case.
+     *
+     * @throw invalid_argument if the plugin could not be found
+     * @see findPluginElement
+     */
+    sdf::ElementPtr getPluginElementByName(sdf::ElementPtr enclosing,
+        std::string const& plugin_name);
+
+    /** Get a typed parameter from the given element
+     *
+     * If the parameter does not exist, use a default value
+     */
+    template <class T>
+    T getParameter(std::string plugin_name,
+        sdf::ElementPtr element,
+        std::string parameter_name,
+        std::string dimension,
+        T default_value)
+    {
+        gzmsg << plugin_name << ": " << parameter_name;
+        if (element->HasElement(parameter_name.c_str())) {
+            T var = element->Get<T>(parameter_name.c_str());
+            gzmsg << "=" << var << " " << dimension << std::endl;
+            return var;
+        }
+        else {
+            gzmsg << " using default " << default_value << " " << dimension << std::endl;
+            return default_value;
+        }
+    }
+
+    /** Get the scope of a topic that is relative to the given model
+     */
+    std::string computeModelTopicScope(gazebo::physics::ModelPtr model);
+
+    /** Get the scope of a topic that is published by the given plugin
+     */
+    std::string computePluginTopicScope(gazebo::physics::ModelPtr model,
+        sdf::ElementPtr plugin);
+
+    /** Compute the actual name of a link based on a relative link name from the SDF
+     *
+     * To account for model inclusions, a plugin in an included model that has to
+     * resolve a link name will have to prepend the path between the root model
+     * and the parent model of the plugin.
+     *
+     * This method assumes that the plugin name has been re-scoped that way, i.e.
+     * that the relative path to the root is simply everything before :: in
+     * the plugin name
+     */
+    gazebo::physics::LinkPtr resolveLink(gazebo::physics::ModelPtr model,
+        sdf::ElementPtr plugin,
+        std::string const& link_name);
+
+    /** Resolve a link from name if an attribute provides it, or return the first link
+     * of the model
+     *
+     * @param model the reference gazebo model. If no link is defined in the plugin
+     *    description, its first link is returned instead.
+     * @param plugin the plugin SDF definition
+     * @param element_name the name of the element that contains the link name. If
+     *    it not present, the function will return the first link of the model.
+     */
+    gazebo::physics::LinkPtr resolveLinkWithDefault(gazebo::physics::ModelPtr model,
+        sdf::ElementPtr plugin_sdf,
+        std::string const& element_name);
+}
+
+#endif


### PR DESCRIPTION
This leverages the rock_gazebo_helpers to properly resolve the link on which the
plugin should act. It fixes two bugs:
- if the link is not specified, including models won't change what link is
  active. Before, it would pick the first link of the resulting composite model
  (that is, the first link of the first included model)
- if the link is specified, it does resolve it even if the model is deeply
  included