### PR TITLE
fix: properly compute the inertia w.r.t. the reference link and not the model

### DIFF
--- a/src/GazeboUnderwater.hpp
+++ b/src/GazeboUnderwater.hpp
@@ -30,7 +30,7 @@ namespace gazebo_underwater
             T getParameter(std::string parameter_name, std::string dimension, T default_value) const;
             double calculateSubmersedRatio() const;
             Inertial computeModelInertial(ModelPtr model, LinkPtr link, sdf::ElementPtr sdf) const;
-            Inertial computeLinkInertial(LinkPtr current_link) const;
+            Inertial computeLinkInertial(LinkPtr current_link, LinkPtr ref_link) const;
             Vector6 getModelFrameVelocities();
             void publishInertia(Matrix6 const& comp_inertia, ignition::math::Vector3d const& cog);
             void initComNode(void);


### PR DESCRIPTION
So far it worked because we had a 1:1 between models and rigid bodies. But with the integration of the bravo, this assumption broke down and the simulation was applying the forces in a very VERY wrong place.